### PR TITLE
Molpro: Updated output.json for ccsd_water_gradient

### DIFF
--- a/qcenginerecords/molpro/ccsd_water_gradient/output.json
+++ b/qcenginerecords/molpro/ccsd_water_gradient/output.json
@@ -67,7 +67,6 @@
       0.0280044096748537
     ],
     "scf_total_energy": -74.4593745474439,
-    "ccsd_correlation_energy": -0.324127345582,
     "ccsd_total_energy": -74.783501893026
   },
   "error": null


### PR DESCRIPTION
Minor update to the output.json for ccsd_water_gradient. Removed the key 'ccsd_correlation_energy' since it is not provided in the xml file when a ccsd gradient calculation is run. 
