### PR TITLE
allow pydantic v2 with v1 api

### DIFF
--- a/devtools/conda-envs/test_env.yaml
+++ b/devtools/conda-envs/test_env.yaml
@@ -8,7 +8,7 @@ dependencies:
 
     # Required depends
   - qcelemental
-  - pydantic >= 0.20
+  - pydantic>=1.8.2
 
     # Testing
   - pytest

--- a/qcenginerecords/info.py
+++ b/qcenginerecords/info.py
@@ -2,9 +2,9 @@ import os
 import qcelemental as qcel
 from typing import Dict, List, Set
 try:
-    from pydantic.v1.main import BaseModel
+    from pydantic.v1 import BaseModel
 except ImportError:
-    from pydantic.main import BaseModel
+    from pydantic import BaseModel
 
 _basedir = os.path.dirname(os.path.abspath(__file__))
 

--- a/qcenginerecords/info.py
+++ b/qcenginerecords/info.py
@@ -1,7 +1,10 @@
 import os
 import qcelemental as qcel
 from typing import Dict, List, Set
-from pydantic import BaseModel
+try:
+    from pydantic.v1.main import BaseModel
+except ImportError:
+    from pydantic.main import BaseModel
 
 _basedir = os.path.dirname(os.path.abspath(__file__))
 

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
     # author_email='me@place.org',      # Author email
     # url='http://www.my_package.com',  # Website
     install_requires=[
-        "pydantic >= 0.20",
+        "pydantic >= 1.8.2",
         'msgpack >= 0.6.1',
         'qcelemental >= 0.11.0',
     ],              # Required packages, pulls from pip if needed; do not use for Conda deployment


### PR DESCRIPTION
## Description
Apply Levi's trick like https://github.com/MolSSI/QCElemental/pull/314 and https://github.com/MolSSI/QCEngine/pull/412 to allow QCEngineRecords to work with pydantic v1 or v2

## Status
- [x] Ready to go
